### PR TITLE
splits typing for channels component

### DIFF
--- a/ui-src/src/cells/holo-chat/components/channels/channelData.ts
+++ b/ui-src/src/cells/holo-chat/components/channels/channelData.ts
@@ -1,0 +1,5 @@
+export const channelData = [{
+  "hash": "QmYodaHMeU8Su5H8G4ByZvumBvYcNrX8JrDKYQRKN8hasp",
+  "name": "dev hApps",
+  "description": "dev-happs"
+}]

--- a/ui-src/src/cells/holo-chat/components/channels/channels.story.tsx
+++ b/ui-src/src/cells/holo-chat/components/channels/channels.story.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {Provider} from 'react-redux'
 import { storiesOf } from "@storybook/react";
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter } from 'react-router-dom'
 import { withNotes } from '@storybook/addon-notes'
 import {configure} from 'enzyme'
 import * as Adapter from 'enzyme-adapter-react-16'
@@ -20,7 +20,7 @@ import { filterAgentsTests } from './filterAgents.test'
 import { selectAgentTests } from './selectAgent.test'
 import { newChatTests } from './newChat.test'
 import { channelsTests } from './channels.test'
-import channelData from '../../data/channels.json'
+import { channelData } from './channelData'
 
 configure({adapter: new Adapter()})
 let store = CreateStore()
@@ -37,7 +37,7 @@ storiesOf('HoloChat/Channels', module)
   ))
   .add('List my Channels', withNotes(listChannels) (() => {
     specs(() => channelsTests)
-    return <Provider store={store}><MemoryRouter initialEntries={['/']}><Channels channels={channelData} /></MemoryRouter></Provider>
+    return <Provider store={store}><Channels channels={channelData} personasList={() => {}} /></Provider>
   }))
   .add('Start a new Channel', withNotes(newChannel) (() => {
     specs(() => newChannelTests)

--- a/ui-src/src/cells/holo-chat/components/channels/channels.test.tsx
+++ b/ui-src/src/cells/holo-chat/components/channels/channels.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Channels, {ChannelsState, ChannelsProps} from './channels';
+import Channels, {State, Props} from './channels';
 import * as Enzyme from 'enzyme';
 import { mount, ReactWrapper } from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
@@ -13,8 +13,8 @@ Enzyme.configure({ adapter: new Adapter() })
 
 export const channelsTests = describe('Listing your channels', () => {
 
-  let props: ChannelsProps
-  let mountedChannelsList: ReactWrapper<ChannelsProps, ChannelsState> | undefined
+  let props: Props
+  let mountedChannelsList: ReactWrapper<Props, State> | undefined
 
   const channelsList = () => {
     if (!mountedChannelsList) {
@@ -31,7 +31,6 @@ export const channelsTests = describe('Listing your channels', () => {
   describe('When there is a list of existing channels', () => {
     beforeEach(() => {
       props = {
-        history: [],
         getMyChannels: mockFn,
         newChannel: mockFn,
         setActiveChannel: mockFn,

--- a/ui-src/src/cells/holo-chat/components/channels/channels.test.tsx
+++ b/ui-src/src/cells/holo-chat/components/channels/channels.test.tsx
@@ -6,7 +6,7 @@ import * as Adapter from 'enzyme-adapter-react-16';
 import CreateStore from '../../../../store'
 import {Provider} from 'react-redux'
 import { MemoryRouter } from 'react-router'
-
+import {channelData} from './channelData'
 
 let store = CreateStore()
 Enzyme.configure({ adapter: new Adapter() })
@@ -37,8 +37,8 @@ export const channelsTests = describe('Listing your channels', () => {
         getUsers: mockFn,
         setIdentity: mockFn,
         personasList: mockFn,
-        channels: [
-        ]
+        channels: channelData
+
       };
     })
 

--- a/ui-src/src/cells/holo-chat/components/channels/channels.tsx
+++ b/ui-src/src/cells/holo-chat/components/channels/channels.tsx
@@ -159,4 +159,4 @@ class Channels extends React.Component<Props & RouterProps, State> {
 }
 
 // typecase after withRouter exposes only non-router props to external use. This is because withRouter will add those props automatically
-export default withRoot(withStyles(styles)(withRouter(Channels) as React.ComponentType<Props>));
+export default withRoot(withStyles(styles)(withRouter(Channels)));

--- a/ui-src/src/cells/holo-chat/components/channels/channels.tsx
+++ b/ui-src/src/cells/holo-chat/components/channels/channels.tsx
@@ -4,13 +4,12 @@ import Typography from '@material-ui/core/Typography';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import Button from '@material-ui/core/Button';
-import { withRouter } from 'react-router-dom'
 import ListItemText from '@material-ui/core/ListItemText';
 import AddIcon from '@material-ui/icons/Add'
 import { Channel as ChannelType, ChannelSpec } from '../../types/model/channel'
 import {Persona} from '../../../holo-vault/types/profile'
 import withRoot from '../../../../withRoot';
-import {Route, RouteComponentProps} from 'react-router-dom'
+import {withRouter, Route, RouteComponentProps} from 'react-router-dom'
 import NewChannel from '../../containers/newChannelContainer'
 import {IdentitySpec} from '../../types/model/identity'
 
@@ -24,10 +23,17 @@ const styles: StyleRulesCallback = (theme: Theme) => ({
   }
 });
 
-export interface ChannelsProps extends RouteComponentProps<{}> {
-  classes?: any,
-  channels: Array<ChannelType>,
 
+
+export interface OwnProps {
+  classes?: any
+}
+
+export interface StateProps {
+  channels: Array<ChannelType>
+}
+
+export interface DispatchProps {
   getMyChannels: () => void,
   newChannel: (channelSpec: ChannelSpec) => void,
   setActiveChannel: (channel: ChannelType) => void,
@@ -36,13 +42,22 @@ export interface ChannelsProps extends RouteComponentProps<{}> {
   setIdentity: (identity: IdentitySpec) => void
 }
 
-export interface ChannelsState {
+export interface RouterProps extends RouteComponentProps<{}> {}
+
+export type Props = OwnProps & StateProps & DispatchProps
+
+
+
+export interface State {
   modalOpen: boolean
 }
 
-class Channels extends React.Component<ChannelsProps, ChannelsState> {
+
+
+
+class Channels extends React.Component<Props & RouterProps, State> {
   getChannelsInterval: any
-  constructor(props: ChannelsProps) {
+  constructor(props: Props & RouterProps) {
     super(props)
     this.state = {
       modalOpen: false
@@ -116,7 +131,7 @@ class Channels extends React.Component<ChannelsProps, ChannelsState> {
     history.push(`/holo-chat/messages`)
   }
 
-  render() {
+  render(): JSX.Element {
     const {classes, channels} = this.props;
     return (<div className={classes.root}>
       <Button variant='fab' mini={true} onClick={this.handleNewChannelButtonClick} className={classes.addButton}>
@@ -143,5 +158,5 @@ class Channels extends React.Component<ChannelsProps, ChannelsState> {
   }
 }
 
-
-export default withRoot(withStyles(styles)(withRouter(Channels)));
+// typecase after withRouter exposes only non-router props to external use. This is because withRouter will add those props automatically
+export default withRoot(withStyles(styles)(withRouter(Channels) as React.ComponentType<Props>));

--- a/ui-src/src/cells/holo-chat/containers/channelsContainer.ts
+++ b/ui-src/src/cells/holo-chat/containers/channelsContainer.ts
@@ -1,9 +1,9 @@
 
 import { connect } from 'react-redux'
-import Channels from '../components/channels/channels'
-// import channelData from '../data/channels.json'
-// import {HoloChatState} from '../reducer'
+import Channels, { OwnProps, StateProps, DispatchProps } from '../components/channels/channels'
+import {  } from '../reducer'
 import {Dispatch} from 'redux'
+
 import {
 	getMyChannels,
 	createCustomChannel,
@@ -21,13 +21,13 @@ import {IdentitySpec} from '../types/model/identity'
 
 
 
-const mapStateToProps = (state: any) => {
+const mapStateToProps = (state: any, ownProps: OwnProps): StateProps => {
   return {
     channels: state.holoChat.myChannels,
   }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch) => {
+const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps): DispatchProps => {
   return {
   	getMyChannels: () => { dispatch(getMyChannels()) },
   	newChannel: (channelSpec: ChannelSpec) => { dispatch(createCustomChannel(channelSpec)) },
@@ -38,7 +38,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
   }
 }
 
-export default connect(
+export default connect<StateProps, DispatchProps, OwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(Channels)


### PR DESCRIPTION
Modified the typing for channels by decomposing it in to props provided by withRouter, mapState and mapDispatch. This has increased the type strictness for using the channels container and also means the type system won't complain if you don't give the routerProps (as in channels.test.tsx)