### PR TITLE
get all public channels

### DIFF
--- a/dna-src/holo-chat/test/index.js
+++ b/dna-src/holo-chat/test/index.js
@@ -12,18 +12,18 @@ app.start()
 /*----------  Chat  ----------*/
 
 
-// const testNewChannelParams = {
-//   name: "test new channel",
-//   description: "for testing...",
-//   initial_members: [],
-//   public: true
-// }
+const testNewChannelParams = {
+  name: "test new channel",
+  description: "for testing...",
+  initial_members: [],
+  public: true
+}
 
-// const testMessage = {
-//   message_type: "text",
-//   payload: "I am the message payload",
-//   meta: "{}",
-// }
+const testMessage = {
+  message_type: "text",
+  payload: "I am the message payload",
+  meta: "{}",
+}
 
 // test('Can create a public channel with no other members and retrieve it', (t) => {
 //   const init_result = app.call('chat', 'main', 'init', {})
@@ -308,10 +308,26 @@ test('chat vault integration', t => {
   t.notEqual(initResult2.Ok, undefined, "Should return Ok as a profile exists!")
 
   // should be able to retrieve this users profile
-  const getAllMembersResutlt = app.call("chat", "main", "get_all_members", {})
-  console.log(getAllMembersResutlt.Ok[0].profile)
-  t.notEqual(getAllMembersResutlt.Ok[0].profile, undefined)
+  const getAllMembersResult = app.call("chat", "main", "get_all_members", {})
+  console.log(getAllMembersResult)
+  t.notEqual(getAllMembersResult.Ok[0].profile, undefined)
+
+
+  // get all members
+
+
+  const getAllStreamsResult = app.call("chat", "main", "get_all_public_streams", {})
+  console.log(getAllStreamsResult)
+  t.deepEqual(getAllStreamsResult.Ok.length, 0, 'no streams have been created yet')
+
+
+  const createResult = app.call('chat', 'main', 'create_stream', testNewChannelParams)
+  console.log(createResult)
+  t.deepEqual(createResult.Ok.length, 46)
+
+  const getAllStreamsResult2 = app.call("chat", "main", "get_all_public_streams", {})
+  console.log(getAllStreamsResult2)
+  t.deepEqual(getAllStreamsResult2.Ok.length, 1, 'a single public stream should be created')
 
   t.end()
 })
-

--- a/dna-src/holo-chat/zomes/chat/code/src/anchor/mod.rs
+++ b/dna-src/holo-chat/zomes/chat/code/src/anchor/mod.rs
@@ -34,6 +34,18 @@ pub fn anchor_definition() -> ValidatingEntryType {
                 validation: |_base: Address, _target: Address, _ctx: hdk::ValidationData| {
                     Ok(())
                 }
+            ),
+            to!(
+                "public_stream",
+                tag: "public_stream",
+
+                validation_package: || {
+                    hdk::ValidationPackageDefinition::Entry
+                },
+
+                validation: |_base: Address, _target: Address, _ctx: hdk::ValidationData| {
+                    Ok(())
+                }
             )
         ]
     )

--- a/dna-src/holo-chat/zomes/chat/code/src/lib.rs
+++ b/dna-src/holo-chat/zomes/chat/code/src/lib.rs
@@ -80,6 +80,11 @@ define_zome! {
 				outputs: |result: ZomeApiResult<()>|,
 				handler: stream::handlers::handle_add_members
 			}
+			join_stream: {
+				inputs: |stream_address: HashString|,
+				outputs: |result: ZomeApiResult<()>|,
+				handler: stream::handlers::handle_join_stream
+			}
 			post_message: {
 				inputs: |stream_address: HashString, message: message::MessageSpec, subjects: Vec<String>|,
 				outputs: |result: ZomeApiResult<()>|,

--- a/dna-src/holo-chat/zomes/chat/code/src/lib.rs
+++ b/dna-src/holo-chat/zomes/chat/code/src/lib.rs
@@ -60,6 +60,11 @@ define_zome! {
 				outputs: |result: ZomeApiResult<utils::GetLinksLoadResult<stream::Stream>>|,
 				handler: stream::handlers::handle_get_my_streams
 			}
+			get_all_public_streams: {
+				inputs: | |,
+				outputs: |result: ZomeApiResult<utils::GetLinksLoadResult<stream::Stream>>|,
+				handler: stream::handlers::handle_get_all_public_streams
+			}
             get_all_members: {
 				inputs: | |,
 				outputs: |result: ZomeApiResult<Vec<member::Member>>|,

--- a/dna-src/holo-chat/zomes/chat/code/src/stream/handlers.rs
+++ b/dna-src/holo-chat/zomes/chat/code/src/stream/handlers.rs
@@ -66,6 +66,10 @@ pub fn handle_add_members(stream_address: HashString, members: Vec<Address>) -> 
     Ok(())
 }
 
+pub fn handle_join_stream(stream_address: HashString) -> ZomeApiResult<()> {
+    utils::link_entries_bidir(&member::handlers::get_my_member_id(), &stream_address, "member_of", "has_member")?;
+    Ok(())
+}
 
 pub fn handle_get_my_streams() -> ZomeApiResult<utils::GetLinksLoadResult<Stream>> {
     utils::get_links_and_load_type(&get_my_member_id(), "member_of")


### PR DESCRIPTION
adds a new zome function that can retrieve all public channels even if the current agent was not added